### PR TITLE
Update http3 script with user agent

### DIFF
--- a/http3.go
+++ b/http3.go
@@ -13,8 +13,31 @@ func main() {
         Transport: &http3.RoundTripper{},
         Timeout:   5 * time.Second,
     }
+    
     for i := 0; i < 10; i++ {
-        resp, err := client.Get("https://cloudflare-quic.com/")
+        req, err := http.NewRequest("GET", "https://cloudflare-quic.com/", nil)
+        if err != nil {
+            fmt.Println("Error creating request:", err)
+            continue
+        }
+        
+        // Add real browser headers to bypass Cloudflare
+        req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+        req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
+        req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+        req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+        req.Header.Set("Cache-Control", "no-cache")
+        req.Header.Set("Pragma", "no-cache")
+        req.Header.Set("Sec-Ch-Ua", "\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\"")
+        req.Header.Set("Sec-Ch-Ua-Mobile", "?0")
+        req.Header.Set("Sec-Ch-Ua-Platform", "\"Windows\"")
+        req.Header.Set("Sec-Fetch-Dest", "document")
+        req.Header.Set("Sec-Fetch-Mode", "navigate")
+        req.Header.Set("Sec-Fetch-Site", "none")
+        req.Header.Set("Sec-Fetch-User", "?1")
+        req.Header.Set("Upgrade-Insecure-Requests", "1")
+        
+        resp, err := client.Do(req)
         if err != nil {
             fmt.Println("Error:", err)
             continue


### PR DESCRIPTION
Add comprehensive browser headers to `http3.go` to bypass Cloudflare CDN's bot detection.

The previous script received 403 Forbidden errors from Cloudflare because it lacked standard browser headers. This update includes a real User-Agent, `Sec-Ch-Ua`, `Sec-Fetch-*`, and other headers that mimic a legitimate browser, allowing the HTTP/3 requests to pass through Cloudflare's CDN.

---
<a href="https://cursor.com/background-agent?bcId=bc-62650b21-3c0c-45a1-a91d-66d154036d60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62650b21-3c0c-45a1-a91d-66d154036d60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>